### PR TITLE
NPM Package + Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,39 @@
 ![Pyright](https://github.com/microsoft/pyright/blob/main/docs/img/PyrightLarge.png)
 
-# Setup
+Pyright is a full-featured, standards-based static type checker for Python. It is designed for high performance and can be used with large Python source bases.
+Refer to [the documentation](https://microsoft.github.io/pyright) for installation, configuration, and usage details.
+
+`pyright-extended`, which lives in this repository, is a new Python meta-LSP that includes tools such as `pyright`, `ruff`, and `yapf`.
+
+`pyright-extended` provides the following capabilities:
+- Static analysis (through `pyright-langserver`)
+- Completions (though `pyright-langserver`)
+- Definitions (through `pyright-langserver`)
+- Hover (through `pyright-langserver`)
+- References (through `pyright-langserver`)
+- Formatting (through `yapf`)
+- Renaming (through `pyright-langserver`)
+- Import reorganization (through `ruff`)
+- Linting (through `ruff`, `pyright-langserver`)
+- Types (through `pyright-langserver`)
+
+# Building from source 
 1. Install dependencies
     - `node` and `npm`
     - `ruff`
     - `yapf`
-2. Build: `cd ./packages/pyright && npm run build`
+    - `npm run install:all`
+2. Build the LSP: `cd ./packages/pyright && npm run build`
 3. Mark file as executable: `chmod +x ./packages/pyright/langserver.index.js`
 3. Start LSP in your client of choice: `./packages/pyright/langserver.index.js --stdio`
 
+# Setup 
+
+```bash
+npm i -g @replit/pyright-extended
+```
+
+## Neovim
 An example setup for the Neovim editor looks something like the following:
 
 ```lua
@@ -18,7 +43,7 @@ local util = require 'lspconfig.util'
 if not configs["pyright-extended"] then
   configs["pyright-extended"] = {
     default_config = {
-      cmd = {'/Users/jzhao/projects/pyright-extended/packages/pyright/langserver.index.js', '--stdio'},
+      cmd = {'pyright-langserver', '--stdio'},
       filetypes = { "python" },
       autostart = true,
       root_dir = util.root_pattern('pyproject.toml'),
@@ -38,9 +63,13 @@ end
 lspconfig["pyright-extended"].setup{}
 vim.lsp.set_log_level("INFO")
 ```
+## VSCode
+To use `pyright-extended` in VS Code, you must build the extension from source.
 
-# Subpackages
-## Pyright 
-Pyright is a full-featured, standards-based static type checker for Python. It is designed for high performance and can be used with large Python source bases.
-Refer to [the documentation](https://microsoft.github.io/pyright) for installation, configuration, and usage details.
-
+1. Install deps: `npm run install:all`
+2. Build the `.vsix` file: `cd packages/vscode-pyright; npm run package`, this generates a `.vsix` file
+3. In VS Code, go to extensions
+4. If you have Pylance, remove it, and reload
+5. If Pyright already exists, remove it, and reload
+6. In extensions, select "Install from VSIX..." and pick the .vsix file from step 2
+7. Make a `main.py`, start typing in code, and you should get context help

--- a/package-lock.json
+++ b/package-lock.json
@@ -4491,9 +4491,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -5359,9 +5359,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -15399,9 +15399,9 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -16051,9 +16051,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true
         },
         "ignore-walk": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
         "fix:eslint": "eslint --fix .",
         "check:prettier": "prettier -c .",
         "fix:prettier": "prettier --write .",
-        "check:lockindent": "node ./build/checkLockIndent.js"
+        "check:lockindent": "node ./build/checkLockIndent.js",
+        "build:lsp": "cd packages/pyright && npm run build",
+        "publish:lsp": "npm publish ./packages/pyright --access public"
     },
     "devDependencies": {
         "@types/glob": "^7.2.0",

--- a/packages/pyright-ruff/index.ts
+++ b/packages/pyright-ruff/index.ts
@@ -151,7 +151,7 @@ export function getCodeActions(fp: string, buf: string | null, diags: Diagnostic
 
     // fix all code action, only added if we have track this file as opened (buf exists)
     if (buf) {
-        const fixed = ruffFix(fp, buf)
+        const fixed = ruffFix(fp, buf);
         if (buf !== fixed) {
             const changes = constructChanges([
                 {

--- a/packages/pyright-ruff/index.ts
+++ b/packages/pyright-ruff/index.ts
@@ -151,23 +151,24 @@ export function getCodeActions(fp: string, buf: string | null, diags: Diagnostic
 
     // fix all code action, only added if we have track this file as opened (buf exists)
     if (buf) {
-        const changes = constructChanges([
-            {
-                // range may seem sus but this is what the official ruff lsp actually does https://github.com/astral-sh/ruff-lsp/blob/main/ruff_lsp/server.py#L735-L740
-                range: {
-                    start: {
-                        line: 0,
-                        character: 0,
+        const fixed = ruffFix(fp, buf)
+        if (buf !== fixed) {
+            const changes = constructChanges([
+                {
+                    // range may seem sus but this is what the official ruff lsp actually does https://github.com/astral-sh/ruff-lsp/blob/main/ruff_lsp/server.py#L735-L740
+                    range: {
+                        start: {
+                            line: 0,
+                            character: 0,
+                        },
+                        end: {
+                            line: uinteger.MAX_VALUE,
+                            character: 0,
+                        },
                     },
-                    end: {
-                        line: uinteger.MAX_VALUE,
-                        character: 0,
-                    },
+                    newText: fixed,
                 },
-                newText: ruffFix(fp, buf),
-            },
-        ]);
-        if (Object.keys(changes).length > 0) {
+            ]);
             actions.push(
                 CodeAction.create('Fix all automatically fixable errors', { changes }, CodeActionKind.SourceFixAll)
             );

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "pyright",
-    "version": "1.1.316",
+    "name": "@replit/pyright-extended",
+    "version": "1.1.317",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "pyright",
-            "version": "1.1.316",
+            "name": "@replit/pyright-extended",
+            "version": "1.1.317",
             "license": "MIT",
             "bin": {
                 "pyright": "index.js",

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -2,7 +2,7 @@
     "name": "@replit/pyright-extended",
     "displayName": "pyright-extended",
     "description": "Extending pyright with yapf + ruff",
-    "version": "1.1.316",
+    "version": "1.1.317",
     "license": "MIT",
     "author": {
         "name": "Replit"

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "pyright",
+    "name": "@replit/pyright-extended",
     "displayName": "pyright-extended",
     "description": "Extending pyright with yapf + ruff",
     "version": "1.1.316",
     "license": "MIT",
     "author": {
-        "name": "Microsoft Corporation"
+        "name": "Replit"
     },
-    "publisher": "Microsoft Corporation",
+    "publisher": "Replit",
     "engines": {
         "node": ">=12.0.0"
     },

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -7,6 +7,11 @@
     "author": {
         "name": "Replit"
     },
+    "contributors": [
+        {
+            "name": "Microsoft"
+        }
+    ],
     "publisher": "Replit",
     "engines": {
         "node": ">=12.0.0"


### PR DESCRIPTION
Packaging entirely through Nix turned out to be a pain because of how Lerna does things that node2nix and dream2nix doesn't like :((

We are instead going to publish an NPM package and then turn it into a Nixmodule

Changes:
- Release https://www.npmjs.com/package/@replit/pyright-extended
- Add better docs
- Scripts for building and publishing the LSP dist