### PR TITLE
Make chokidar excludes list match the top-level excludes

### DIFF
--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -44,7 +44,7 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             watcherOptions.usePolling = false;
         }
 
-        const excludes: string[] = ['**/__pycache__/**'];
+        const excludes: string[] = ['**/node_modules', '**/__pycache__', '**/.*'];
         if (_isMacintosh || _isLinux) {
             if (paths.some((path) => path === '' || path === '/')) {
                 excludes.push('/dev/**');


### PR DESCRIPTION
See packages/pyright-internal/src/analyzer/service.ts#L585 for the associated array.

The way pyright works is to eagerly watch everything using chokidar and then filter in the consumer, since the LS doesn't know which workspace we're in.

Initially making this modification here to stop the bleeding, but investigation continues to determine why the typescript server (at the very least) doesn't also suffer from this issue.