### PR TITLE
Ignore non python files

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload mypy_primer diff
         uses: actions/upload-artifact@v4
         with:
-          name: mypy_primer_diffs
+          name: mypy_primer_diffs_${{ matrix.shard-index }}
           path: diff_${{ matrix.shard-index }}.txt
       - if: ${{ matrix.shard-index }} == 0
         name: Save PR number

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -79,11 +79,11 @@ jobs:
         with:
           name: mypy_primer_diffs_${{ matrix.shard-index }}
           path: diff_${{ matrix.shard-index }}.txt
-      - if: ${{ matrix.shard-index }} == 0
+      - if: ${{ matrix.shard-index == 0 }}
         name: Save PR number
         run: |
           echo ${{ github.event.pull_request.number }} | tee pr_number.txt
-      - if: ${{ matrix.shard-index }} == 0
+      - if: ${{ matrix.shard-index == 0 }}
         name: Upload PR number
         uses: actions/upload-artifact@v4
         with:

--- a/packages/pyright-internal/package-lock.json
+++ b/packages/pyright-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyright-internal",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pyright-internal",
-            "version": "2.0.12",
+            "version": "2.0.13",
             "license": "MIT",
             "dependencies": {
                 "@iarna/toml": "2.2.5",

--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -2,7 +2,7 @@
     "name": "pyright-internal",
     "displayName": "pyright",
     "description": "Type checker for the Python language",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "license": "MIT",
     "private": true,
     "files": [

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -17,6 +17,8 @@ const _isMacintosh = process.platform === 'darwin';
 const _isLinux = process.platform === 'linux';
 
 export class ChokidarFileWatcherProvider implements FileWatcherProvider {
+    private _allowedExtensions = ['.py', '.pyi', '.ipynb'];
+
     constructor(private _console?: ConsoleInterface) {}
 
     createFileWatcher(paths: string[], listener: FileWatcherEventHandler): FileWatcher {
@@ -85,7 +87,7 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             }
 
             if (stats && stats.isFile()) {
-                if (!path.basename(testPath).endsWith('.py')) {
+                if (!this._allowedExtensions.some((extension) => path.basename(testPath).endsWith(extension))) {
                     // Ignore non-Python files.
                     return true;
                 }

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -17,7 +17,7 @@ const _isMacintosh = process.platform === 'darwin';
 const _isLinux = process.platform === 'linux';
 
 export class ChokidarFileWatcherProvider implements FileWatcherProvider {
-    private _allowedExtensions = ['.py', '.pyi', '.ipynb'];
+    private _allowedExtensions = ['.py', '.pyi', '.ipynb', '.toml'];
 
     constructor(private _console?: ConsoleInterface) {}
 
@@ -43,6 +43,8 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
         };
 
         if (_isMacintosh) {
+            // Explicitly disable on MacOS because it uses up large amounts of memory
+            // and CPU for large file hierarchies, resulting in instability and crashes.
             watcherOptions.usePolling = false;
         }
 
@@ -87,7 +89,7 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             }
 
             if (stats && stats.isFile()) {
-                return !this._allowedExtensions.some((extension) => path.basename(testPath).endsWith(extension));
+                return !this._allowedExtensions.includes(path.extname(testPath).toLowerCase());
             }
 
             return false;

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -44,7 +44,14 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             watcherOptions.usePolling = false;
         }
 
-        const excludes: string[] = ['**/node_modules/**', '**/__pycache__/**', '**/.*', '**/.*/**'];
+        const excludes: (string | RegExp)[] = [
+            '**/node_modules/**',
+            '**/__pycache__/**',
+            '**/.*',
+            '**/.*/**',
+            /^(?!.*\.py$).+$/, // exclude all files that don't end in .py
+        ];
+
         if (_isMacintosh || _isLinux) {
             if (paths.some((path) => path === '' || path === '/')) {
                 excludes.push('/dev/**');

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -87,10 +87,7 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             }
 
             if (stats && stats.isFile()) {
-                if (!this._allowedExtensions.some((extension) => path.basename(testPath).endsWith(extension))) {
-                    // Ignore non-Python files.
-                    return true;
-                }
+                return !this._allowedExtensions.some((extension) => path.basename(testPath).endsWith(extension));
             }
 
             return false;

--- a/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
+++ b/packages/pyright-internal/src/common/chokidarFileWatcherProvider.ts
@@ -65,8 +65,7 @@ export class ChokidarFileWatcherProvider implements FileWatcherProvider {
             }
 
             // Check if any part of the path starts with a dot (hidden file/directory).
-            // Exclude '.' and '..' to avoid matching the current/parent directory indicators.
-            if (normalizedPath.split('/').some((part) => part.startsWith('.') && part !== '.' && part !== '..')) {
+            if (normalizedPath.split('/').some((part) => part.startsWith('.'))) {
                 return true;
             }
 

--- a/packages/pyright/package-lock.json
+++ b/packages/pyright/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@replit/pyright-extended",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@replit/pyright-extended",
-            "version": "2.0.12",
+            "version": "2.0.13",
             "license": "MIT",
             "bin": {
                 "pyright": "index.js",

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -2,7 +2,7 @@
     "name": "@replit/pyright-extended",
     "displayName": "pyright-extended",
     "description": "Extending pyright with yapf + ruff",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "license": "MIT",
     "author": {
         "name": "Replit"


### PR DESCRIPTION
Why
===

Previously, the LSP watches all the files within the given paths. We could get `ENOSPC: System limit for number of file watchers reached` error in a large codebase with multiple different programming language files.

What changed
============

- The `ignore` option of Chokidar is using [Anymatch](https://github.com/micromatch/anymatch) under the hood, which allows us to pass in a `AnymatchFn` handler function for customizing our own file matching rules. 
- Instead of passing in glob of files, we can write a function that explicitly checks and ignore non-python files.

Test plan
=========

https://replit.com/t/replit/repls/ShouldNotWatchNonPython?replId=dfb12081-2bb1-49b6-8080-5961e0980de9#.replit

In this python repl, we have both the original version pyright-extended running and a version of this PR. And there are 2000 non python files created in the repl. We can see that the original pyright-extended LSP watches 2000 extra files compared to the other one.
<img width="994" alt="image" src="https://github.com/user-attachments/assets/80c14220-84f8-4b42-bd40-b8a76483d116" />


