### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -75,7 +75,7 @@ jobs:
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
       - name: Upload mypy_primer diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mypy_primer_diffs
           path: diff_${{ matrix.shard-index }}.txt
@@ -85,7 +85,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} | tee pr_number.txt
       - if: ${{ matrix.shard-index }} == 0
         name: Upload PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mypy_primer_diffs
           path: pr_number.txt


### PR DESCRIPTION
Why
===

actions/upload-artifact@v3 is deprecated causing CI to fail.

https://github.com/replit/pyright-extended/actions/runs/14611889286/job/40991362547

What changed
============

- Update to actions/upload-artifact@v4

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
